### PR TITLE
Fixed load order in local settings example

### DIFF
--- a/cloudtunes-server/cloudtunes/settings/local.example.py
+++ b/cloudtunes-server/cloudtunes/settings/local.example.py
@@ -16,14 +16,14 @@ REDIS = {
 }
 
 
+WEB_APP_DIR = path.realpath(ROOT + '/../cloudtunes-webapp/build/production')
+
+
 TORNADO_APP.update({
     'static_path': WEB_APP_DIR,
     'debug': DEBUG,
     'cookie_secret': None
 })
-
-
-WEB_APP_DIR = path.realpath(ROOT + '/../cloudtunes-webapp/build/development')
 
 
 EMAIL = {


### PR DESCRIPTION
Having WEB_APP_DIR defined after the TORNADO_APP.update() call caused our locally defined 'static path' to be overwritten by the defaults. The codebase also seems to only ship with a 'production' webapp build directory, but the example settings file had 'development'.
