### PR TITLE
Fixes issue with missing npm modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,7 @@ ADD cloudtunes-server/production/supervisor.ini \
 ADD cloudtunes-webapp /home/cloudtunes/cloudtunes-webapp
 RUN npm install ./cloudtunes-webapp
 RUN cd cloudtunes-webapp \
+    && npm install \
     && brunch build --production --config=config-dist.coffee
 
 


### PR DESCRIPTION
Fixes #14 

Previous error:

```
11 Sep 13:55:05 - warn: `-c, --config` option is deprecated. Use `--env` and `config.overrides` instead

/usr/lib/node_modules/brunch/lib/watch.js:428
            throw new Error("You probably need to execute `npm install` to ins
                  ^
Error: You probably need to execute `npm install` to install brunch plugins. Error: Cannot find module '/home/cloudtunes/cloudtunes-webapp/node_modules/javascript-brunch'
  at /usr/lib/node_modules/brunch/lib/watch.js:428:19
  at Array.map (native)
  at loadDeps (/usr/lib/node_modules/brunch/lib/watch.js:413:10)
  at loadPackages (/usr/lib/node_modules/brunch/lib/watch.js:433:15)
  at /usr/lib/node_modules/brunch/lib/watch.js:453:19
  at /usr/lib/node_modules/brunch/lib/helpers.js:517:16
  at /usr/lib/node_modules/brunch/lib/helpers.js:473:14
  at /usr/lib/node_modules/brunch/node_modules/read-components/index.js:263:16
  at /usr/lib/node_modules/brunch/node_modules/read-components/index.js:72:14
  at Object.cb [as oncomplete] (fs.js:168:19)
```
