### PR TITLE
Removed unused required modules inside PlayQueue module

### DIFF
--- a/cloudtunes-webapp/app/models/lists/play_queue.coffee
+++ b/cloudtunes-webapp/app/models/lists/play_queue.coffee
@@ -1,8 +1,5 @@
 Backbone = require 'backbone'
 _ = require 'underscore'
-{NullOrdering} = require 'models/lists/states'
-TrackList = require 'models/lists/tracklist'
-
 
 class PlayQueue
 


### PR DESCRIPTION
Couldn't see these modules being used by the PlayQueue module so figured they may as well be removed.

Disclaimer: I've not tested this change, just something I saw when reading the codebase that I think is safe to remove.