### PR TITLE
Improved docker installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,24 +11,13 @@ ENV PATH "$PATH:/usr/bin"
 
 ### Setup system ###
 
-# Install mongodb from ppa
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10 \
-    && echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' \
-        | tee /etc/apt/sources.list.d/mongodb.list \
-    && apt-get -y update \
-    && apt-get -y install mongodb-org \
-    && mkdir -p /data/db
-
-# Mongo DB and Redis will store their data in /data; make it a VOLUME.
-VOLUME ["/data"]
-
 # Add nodejs repository and install required packages
 RUN apt-get -y install curl
 RUN curl -sL https://deb.nodesource.com/setup | sudo bash -
 
 # Install system dependencies
 RUN apt-get -y update
-RUN apt-get -y install redis-server supervisor nginx python-dev python-pip \
+RUN apt-get -y install supervisor nginx python-dev python-pip \
                git ruby python-software-properties python g++ make nodejs \
                build-essential ruby-dev
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CloudTunes
 
-**Open source, web-based music player for the cloud.** 
+**Open source, web-based music player for the cloud.**
 <br/>
 Also on: [Facebook](https://www.facebook.com/cloudtunes "/cloudtunes") •
 [Twitter](https://twitter.com/cloudtunesapp "@cloudtunesapp") •
@@ -10,12 +10,12 @@ Also on: [Facebook](https://www.facebook.com/cloudtunes "/cloudtunes") •
 ![screenshot](screenshots/Homepage.png)
 
 
-CloudTunes provides a unified interface 
-for music stored in the cloud (YouTube, Dropbox, etc.) and integrates with 
-[Last.fm](http://www.last.fm/api), Facebook, 
-and [Musicbrainz](https://musicbrainz.org/) for metadata, discovery, 
-and social experience. It is similar to services like Spotify, 
-except instead of local tracks and the fixed Spotify catalog, 
+CloudTunes provides a unified interface
+for music stored in the cloud (YouTube, Dropbox, etc.) and integrates with
+[Last.fm](http://www.last.fm/api), Facebook,
+and [Musicbrainz](https://musicbrainz.org/) for metadata, discovery,
+and social experience. It is similar to services like Spotify,
+except instead of local tracks and the fixed Spotify catalog,
 CloudTunes uses your files stored in Dropbox and music videos on YouTube.
 
 
@@ -26,22 +26,22 @@ CloudTunes uses your files stored in Dropbox and music videos on YouTube.
 
 ## The Story
 
-CloudTunes is a side project of 
-[@jkbrzt](https://twitter.com/jkbrzt) who is a bit of a 
-[music nerd](http://last.fm/user/oswaldcz) and who likes to 
-[build stuff](https://github.com/jkbrzt). In 2012 he decided 
-to create an iTunes-like webapp to **make music stored all over the cloud 
-easily discoverable and accessible:** hence *CloudTunes*. 
+CloudTunes is a side project of
+[@jkbrzt](https://twitter.com/jkbrzt) who is a bit of a
+[music nerd](http://last.fm/user/oswaldcz) and who likes to
+[build stuff](https://github.com/jkbrzt). In 2012 he decided
+to create an iTunes-like webapp to **make music stored all over the cloud
+easily discoverable and accessible:** hence *CloudTunes*.
 
 Another one of the goals was to experiment with a bunch of new technologies.
-Later, this side-project was largely abandoned due to other more pressing 
-projects. In the autumn of 2014, CloudTunes was open-sourced *"as is"* 
+Later, this side-project was largely abandoned due to other more pressing
+projects. In the autumn of 2014, CloudTunes was open-sourced *"as is"*
 (i.e. alpha quality, lack of polish, tests and docs).
 
 
 ## Technology
 
-The architecture consists of a server and client component. Those two are 
+The architecture consists of a server and client component. Those two are
 decoupled and communicate via a JSON REST API and a WebSocket connection:
 
 
@@ -51,8 +51,8 @@ decoupled and communicate via a JSON REST API and a WebSocket connection:
 Written in **Python,** uses Tornado, Celery, Mongo DB, MongoEngine, Redis.
 
 
-### [`cloudtunes-webapp`](cloudtunes-webapp) 
-**Single-page app.** Written in **CoffeeScript and Sass,** uses Brunch, 
+### [`cloudtunes-webapp`](cloudtunes-webapp)
+**Single-page app.** Written in **CoffeeScript and Sass,** uses Brunch,
 Backbone.js, SocketIO, Handlebars, Compass, SoundManager.
 
 
@@ -77,7 +77,7 @@ Any album or track you like can be added to your collection or any of your playl
 
 Access and stream **music that you already have in Dropbox** from any computer.
 Fast indexing and realtime updates.
- 
+
 ![screenshot](screenshots/Dropbox.png)
 
 
@@ -86,7 +86,7 @@ Fast indexing and realtime updates.
 
 ### Playlists
 
-Organise your collection with playlists. Drag and drop tracks and 
+Organise your collection with playlists. Drag and drop tracks and
 albums on a playlist to add them. You can create playlists containing both tracks from your Dropbox and music videos from YouTube.
 
 ![screenshot](screenshots/DnD.png)
@@ -95,7 +95,7 @@ albums on a playlist to add them. You can create playlists containing both track
 
 ### Last.fm Support
 
-Scrobble and play your personalised recommendations. 
+Scrobble and play your personalised recommendations.
 
 ![screenshot](screenshots/Scrobbling.png)
 ![screenshot](screenshots/Explore-Trending.png)
@@ -123,47 +123,12 @@ Scrobble and play your personalised recommendations.
 
 ## Installation
 
-1. Clone this repository:
-
-  ```bash
-  $ git clone https://github.com/jkbrzt/cloudtunes.git
-  $ cd cloudtunes
-  ```
-
-2. Use [`cloudtunes-server/cloudtunes/settings/local.example.py`](cloudtunes-server/cloudtunes/settings/local.example.py) as a template and fill in the `None`'s:
-
-  ```bash
-  $ cp  cloudtunes-server/cloudtunes/settings/local.example.py cloudtunes-server/cloudtunes/settings/local.py
-  $ vim cloudtunes-server/cloudtunes/settings/local.py
-  ```
-3. Decide whether to continue with or without Docker and follow the specific instructions below.
-
-### Without Docker
-
-Continue by following the instructions in:
-
-* [`cloudtunes-server/README`](cloudtunes-server)
-* [`cloudtunes-webapp/README`](cloudtunes-webapp)
-
-### With Docker
-
-The easiest way to run CloudTunes is in an isolated 
-[Docker](https://docker.com/whatisdocker/) container. Like this, 
-the only thing you need to install directly on your system is Docker 
-(or `boot2docker`) itself.
-
-Please follow the 
-[installation instructions](https://docs.docker.com/installation/#installation) 
-on how to install Docker (or `boot2docker`) on your system. Then follow the
-steps bellow:
-
-
-1.  **Build** a Docker image according to our [`Dockerfile`](Dockerfile) 
+1.  **Build** a Docker image according to our [`Dockerfile`](Dockerfile)
   and name it `cloudtunes-img`. This takes a long time the first time
   it's run:
 
   ```bash
-  $ docker build --tag=cloudtunes-img .
+  $ docker build -t cloudtunes-img .
   ```
 
 2. **Verify** that the image has been created:
@@ -174,53 +139,53 @@ steps bellow:
   cloudtunes-img      latest              e1bcb48ab148        About an hour ago   995.1 MB
   ```
 
-3. **Create** a new container named `cloudtunes ` from the `cloudtunes-img` 
+3. **Create** a new container named `cloudtunes` from the `cloudtunes-img`
   image and run the app in it:
 
   ``` bash
-  $ docker run --name=cloudtunes --publish=8000:8000  --detach --tty cloudtunes-img
+  $ docker run -dt --name cloudtunes -p 8000:8000 cloudtunes-img
   ```
 
-4. **Verify** the container is running:
-
+4. **Create** two new containers with mongo and redis databases from their official docker images
   ```bash
-  $ docker ps
-  CONTAINER ID        IMAGE                   COMMAND                CREATED             STATUS              PORTS                    NAMES
-  564cc245e6dd        cloudtunes-img:latest   "supervisord --nodae   52 minutes ago      Up 2 minutes        0.0.0.0:8000->8000/tcp   cloudtunes
-  
+  $ docker run -dt --name mongo -v cloudtunes-mongo-data:/data/db --net container:cloudtunes mongo:latest
+  $ docker run -dt --name cloudtunes-redis -v cloudtunes-redis-data:/data --net container:cloudtunes redis:alpine redis-server --appendonly yes
   ```
-  
-5. Now CloudTunes should be running in the Docker container on port `8000`. 
+
+6. Now CloudTunes should be running in the Docker container on port `8000`.
   The full URL depends on the method you used to install Docker:
 
-  * If you have installed **Docker directly** on your system, the full 
+  * If you have installed **Docker directly** on your system, the full
     URL will simply be: [`http://localhost:8000/`](http://localhost:8000/)
-  * If you have used **`boot2docker`,** then run `$ boot2docker ip` 
-    to find out the IP address under which the app is available, 
+  * If you have used **`boot2docker`,** then run `$ boot2docker ip`
+    to find out the IP address under which the app is available,
     and the full URL will be `http://<boot2docker IP>:8000/`
 
 
 To stop the app (Docker container), run:
 
 ```bash
-$ docker stop cloudtunes
+$ docker stop {cloudtunes, cloudtunes-mongo, cloudtunes-redis}
 ```
 
 To start it again, run:
+
 ```bash
-$ docker start cloudtunes
+$ docker start {cloudtunes, cloudtunes-mongo, cloudtunes-redis}
 ```
 
-All user data (stored by MongoDB and Redis under `/data`) will persist until the container has been deleted.  
+All user data (stored by MongoDB and Redis in `cloudtunes-mongo-data` and `cloudtunes-redis-data` docker volumes) will persist until the
+volumes has been deleted (persist even with containers deleted).  
 
-After you have made any changes to the codebase or configuration and 
-want them to be applied to the container, or if you simply wish to start 
-from scratch again, run the following commands to delete the 
+After you have made any changes to the codebase or configuration and
+want them to be applied to the container, or if you simply wish to start
+from scratch again, run the following commands to delete the
 existing container (*this will also delete all user data in it*):
 
 ```bash
-$ docker stop cloudtunes
-$ docker rm cloudtunes
+$ docker stop {cloudtunes, cloudtunes-mongo, cloudtunes-redis}
+$ docker rm {cloudtunes, cloudtunes-mongo, cloudtunes-redis}
+$ docker volume rm {cloudtunes-mongo-data, cloudtunes-redis-data}
 ```
 
 And then start again from step 1. above (it should go much faster this time).
@@ -229,7 +194,7 @@ And then start again from step 1. above (it should go much faster this time).
 
 BSD. See [LICENSE](LICENSE) for more details.
 
-## Contact 
+## Contact
 
 Jakub Roztočil
 


### PR DESCRIPTION
Instead of using only one docker image with databases included in it, use 3 images:
1. https://hub.docker.com/_/mongo/
2. https://hub.docker.com/_/redis/
3. cloudtunes

Why is it better:  
- "docker style" is to have only one main process per container.
- faster build of cloudtunes image
- up-to-date versions of redis and mongo 
- smaller image size
